### PR TITLE
fix line searching for ld-linux for 32bits binary

### DIFF
--- a/packelf.sh
+++ b/packelf.sh
@@ -62,7 +62,7 @@ pack() {
     shift
 
     libs="$(ldd "$src" | grep -F '/' | sed -E 's|[^/]*/([^ ]+).*?|/\1|')"
-    ld_so="$(echo "$libs" | grep -F '/ld-linux-' || echo "$libs" | grep -F '/ld-musl-')"
+    ld_so="$(echo "$libs" | grep -F '/ld-linux' || echo "$libs" | grep -F '/ld-musl-')"
     ld_so="$(basename "$ld_so")"
     program="$(basename "$src")"
 


### PR DESCRIPTION
I tried this utility to pack a legacy 32bit binary we need to execute in our compute cluster and I had to apply this small fix.

`packelf` was working fine to pack 64bits binaries because the path to the ld-linux linker is like this:

```
$ ldd /bin/ls | grep -F '/' | sed -E 's|[^/]*/([^ ]+).*?|/\1|' |grep ld-linux
/lib64/ld-linux-x86-64.so.2
```

but in my binary the path for `ld-linux` was like this and the grep command was not matching with `/lib/ld-linux.so.2`

```
$ ldd sspro4/server/predict_seq_ss | grep -F '/' | sed -E 's|[^/]*/([^ ]+).*?|/\1|' | grep ld-linux
/lib/ld-linux.so.2
```

With this small fix the utility works for both binaries